### PR TITLE
chore(release): :rocket: 0.9.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.9.0](https://github.com/entelecheia/hyperfast-template/compare/v0.8.0...v0.9.0) (2023-10-20)
+
+
+### Features
+
+* **package.json.jinja:** add @semantic-release/exec to devDependencies ([6f3f24d](https://github.com/entelecheia/hyperfast-template/commit/6f3f24d1df68669ae85a173dacb0ed01238b3fdc))
+* **copier.yaml:** add release_branch_name option ([abc2c94](https://github.com/entelecheia/hyperfast-template/commit/abc2c945762fce5c15a2246182945a6d84f3978e))
+
+
+### Bug Fixes
+
+* **copier.yaml:** correct typo in release_branch_name default value ([63fc523](https://github.com/entelecheia/hyperfast-template/commit/63fc52395687d0f588ddd70274f93c135266d176))
+
 ## [0.8.0](https://github.com/entelecheia/hyperfast-template/compare/v0.7.1...v0.8.0) (2023-10-19)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "hyperfast-template",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "hyperfast-template",
-            "version": "0.8.0",
+            "version": "0.9.0",
             "license": "MIT",
             "devDependencies": {
                 "@semantic-release/changelog": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hyperfast-template",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "description": "A general template that helps you jump start your project",
     "author": "Young Joon Lee <entelecheia@hotmail.com>",
     "license": "MIT",


### PR DESCRIPTION
## [0.9.0](https://github.com/entelecheia/hyperfast-template/compare/v0.8.0...v0.9.0) (2023-10-20)

### Features

* **package.json.jinja:** add @semantic-release/exec to devDependencies ([6f3f24d](https://github.com/entelecheia/hyperfast-template/commit/6f3f24d1df68669ae85a173dacb0ed01238b3fdc))
* **copier.yaml:** add release_branch_name option ([abc2c94](https://github.com/entelecheia/hyperfast-template/commit/abc2c945762fce5c15a2246182945a6d84f3978e))

### Bug Fixes

* **copier.yaml:** correct typo in release_branch_name default value ([63fc523](https://github.com/entelecheia/hyperfast-template/commit/63fc52395687d0f588ddd70274f93c135266d176))

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>